### PR TITLE
Payload changes

### DIFF
--- a/Example/TypedNotifications.xcodeproj/project.pbxproj
+++ b/Example/TypedNotifications.xcodeproj/project.pbxproj
@@ -167,12 +167,12 @@
 				TargetAttributes = {
 					B7EBAD081F5871A600A08C26 = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					B7EBAD1C1F5871A600A08C26 = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 1010;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 						TestTargetID = B7EBAD081F5871A600A08C26;
 					};
@@ -387,7 +387,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.TypedNotifications;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -402,7 +402,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.TypedNotifications;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -417,7 +417,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.TypedNotificationsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TypedNotifications.app/TypedNotifications";
 			};
@@ -433,7 +433,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.TypedNotificationsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TypedNotifications.app/TypedNotifications";
 			};

--- a/Example/TypedNotifications.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/TypedNotifications.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/TypedNotifications/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/TypedNotifications/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -84,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ func post<T: TypedNotification>(typedNotification: T, object: Any? = nil)
 ```
 
 ```swift
-func func post<T: TypedPayloadNotification>(typedNotification: T, object: Any? = nil)
+func post<T: TypedPayloadNotification>(typedNotification: T, object: Any? = nil)
 ```
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ### A wrapper around `NotificationCenter` for sending typed notifications with payloads across your iOS app.
 
 [![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=59a836506532420001f89b3b&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/59a836506532420001f89b3b/build/latest?branch=master) 
-[![Pod Version](https://img.shields.io/badge/Pod-1.2-6193DF.svg)](https://cocoapods.org/)
-![Swift Version](https://img.shields.io/badge/Swift%204.2-brightgreen.svg)
+[![Pod Version](https://img.shields.io/badge/Pod-1.3-6193DF.svg)](https://cocoapods.org/)
+![Swift Version](https://img.shields.io/badge/Swift%205.0-brightgreen.svg)
 ![License MIT](https://img.shields.io/badge/License-MIT-lightgrey.svg) 
 ![Plaform](https://img.shields.io/badge/Platform-iOS-lightgrey.svg)
 
@@ -22,11 +22,11 @@ Using TypedNotifications is easy. You can drop it into your app and replace all 
 You can register notifications for either payload containing notifications, or payload-free notifications.
 
 ```swift
-func register<T: TypedNotification>(type: T.Type, observer: Any, selector: Selector)
+func register<T: TypedNotification>(type: T.Type, observer: Any, object: Any? = nil, selector: Selector)
 ```
 
 ```swift
-func register<T: TypedPayloadNotification>(type: T.Type, observer: Any, selector: Selector)
+func register<T: TypedPayloadNotification>(type: T.Type, observer: Any, object: Any? = nil, selector: Selector)
 ```
 ---
 
@@ -35,11 +35,11 @@ func register<T: TypedPayloadNotification>(type: T.Type, observer: Any, selector
 You can send notifications for either payload containing notifications, or payload-free notifications.
 
 ```swift
-func post<T: TypedNotification>(typedNotification: T)
+func post<T: TypedNotification>(typedNotification: T, object: Any? = nil)
 ```
 
 ```swift
-func post<T: TypedPayloadNotification>(typedNotification: T)
+func func post<T: TypedPayloadNotification>(typedNotification: T, object: Any? = nil)
 ```
 ---
 

--- a/Source/TypedNotification.swift
+++ b/Source/TypedNotification.swift
@@ -32,7 +32,7 @@ public extension NotificationCenter {
     /// This function posts notifications, using a generic parameter tailored to `TypedPayloadNotification`s.
     ///
     /// - Parameter typedNotification: The `TypedPayloadNotification` to post.
-    func post<T: TypedPayloadNotification>(typedNotification: T, object: Any?) {
+    func post<T: TypedPayloadNotification>(typedNotification: T, object: Any? = nil) {
         let notification = NotificationCenter.generateNotification(
             typedNotification: typedNotification,
             object: object

--- a/Source/TypedNotification.swift
+++ b/Source/TypedNotification.swift
@@ -3,6 +3,8 @@ import Foundation
 /// A protocol to define notifications that are sent around with our `NotificationCenter` extension functionality.
 public protocol TypedNotification {}
 
+private let userInfoPayloadKey = "_payload"
+
 /// A protocol to define notifications that are sent around with our `NotificationCenter` extension functionality
 /// and contain a payload.
 public protocol TypedPayloadNotification: TypedNotification {
@@ -10,7 +12,7 @@ public protocol TypedPayloadNotification: TypedNotification {
     /// The type must be defined a `Notification`.
     associatedtype Payload
 
-    /// A payload to send in a notification. It is sent through `Notification`'s the `object` property.
+    /// A payload to send in a notification. It is sent through `Notification`'s the `userInfo` property.
     var payload: Payload { get }
 }
 
@@ -19,16 +21,22 @@ public extension NotificationCenter {
     /// This function posts notifications, using a generic parameter tailored to `TypedNotification`s.
     ///
     /// - Parameter typedNotification: The `TypedNotification` to post.
-    func post<T: TypedNotification>(typedNotification: T) {
-        let notification = NotificationCenter.generateNotification(typedNotification: typedNotification)
+    func post<T: TypedNotification>(typedNotification: T, object: Any? = nil) {
+        let notification = NotificationCenter.generateNotification(
+            typedNotification: typedNotification,
+            object: object
+        )
         self.post(notification)
     }
 
     /// This function posts notifications, using a generic parameter tailored to `TypedPayloadNotification`s.
     ///
     /// - Parameter typedNotification: The `TypedPayloadNotification` to post.
-    func post<T: TypedPayloadNotification>(typedNotification: T) {
-        let notification = NotificationCenter.generateNotification(typedNotification: typedNotification)
+    func post<T: TypedPayloadNotification>(typedNotification: T, object: Any?) {
+        let notification = NotificationCenter.generateNotification(
+            typedNotification: typedNotification,
+            object: object
+        )
         self.post(notification)
     }
     
@@ -38,22 +46,31 @@ public extension NotificationCenter {
     ///   - type: The `TypedNotification` type to register.
     ///   - observer: An observer to use for calling the target selector.
     ///   - selector: The selector to call the observer with.
-    func register<T: TypedNotification>(type: T.Type, observer: Any, selector: Selector) {
+    func register<T: TypedNotification>(type: T.Type, observer: Any, object: Any? = nil, selector: Selector) {
         let notificationName = NotificationCenter.generateNotificationName(type: type)
-        self.addObserver(observer, selector: selector, name: notificationName, object: nil)
+        self.addObserver(observer, selector: selector, name: notificationName, object: object)
     }
+
 }
 
 extension NotificationCenter {
 
-    static func generateNotification<T: TypedNotification>(typedNotification: T) -> Notification {
+    static func generateNotification<T: TypedNotification>(typedNotification: T, object: Any? = nil) -> Notification {
         let notificationName = self.generateNotificationName(type: T.self)
-        return Notification(name: notificationName)
+        return Notification(
+            name: notificationName,
+            object: object,
+            userInfo: nil
+        )
     }
 
-    static func generateNotification<T: TypedPayloadNotification>(typedNotification: T) -> Notification {
+    static func generateNotification<T: TypedPayloadNotification>(typedNotification: T, object: Any? = nil) -> Notification {
         let notificationName = self.generateNotificationName(type: T.self)
-        return Notification(name: notificationName, object: typedNotification.payload)
+        return Notification(
+            name: notificationName,
+            object: object,
+            userInfo: [userInfoPayloadKey : typedNotification.payload]
+        )
     }
     
     static func generateNotificationName<T: TypedNotification>(type: T.Type) -> Notification.Name {
@@ -62,6 +79,7 @@ extension NotificationCenter {
 
         return notificationName
     }
+
 }
 
 public extension Notification {
@@ -72,6 +90,7 @@ public extension Notification {
     /// - Parameter notificationType: The notificationType to retrieve the payload from.
     /// - Returns: The payload from the `TypedNotification`.
     func getPayload<T: TypedPayloadNotification>(notificationType: T.Type) -> T.Payload? {
-        return self.object as? T.Payload
+        return self.userInfo?[userInfoPayloadKey] as? T.Payload
     }
+
 }

--- a/Tests/TypedNotificationTests.swift
+++ b/Tests/TypedNotificationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 struct TypedTestNotification: TypedNotification {}
 
 struct TypedPayloadTestNotification: TypedPayloadNotification {
-    
+
     let payload: Bool
     
 }
@@ -14,21 +14,23 @@ final class TypedNotificationTests: XCTestCase {
 
     static let passingValue = true
     static let failingValue = false
+    static let testObject = 42
+
 
     // MARK: TypedNotification properties
-    
+
     let payloadFreeTypedNotification = TypedTestNotification()
 
     lazy var payloadFreeNotification: Notification = {
         return NotificationCenter.generateNotification(typedNotification: self.payloadFreeTypedNotification)
     }()
-    
+
     // MARK: TypedPayloadNotification properties
-    
+
     let passingTypedPayloadNotification = TypedPayloadTestNotification(payload: TypedNotificationTests.passingValue)
-    
+
     lazy var passingNotification: Notification = {
-        return NotificationCenter.generateNotification(typedNotification: self.passingTypedPayloadNotification)
+        return NotificationCenter.generateNotification(typedNotification: self.passingTypedPayloadNotification, object: TypedNotificationTests.testObject)
     }()
 
     let failingTypedPayloadNotification = TypedPayloadTestNotification(payload: TypedNotificationTests.failingValue)
@@ -54,8 +56,15 @@ final class TypedNotificationTests: XCTestCase {
     // MARK: TypedPayloadNotification tests
 
     func testCorrectTypedPayloadNotificationGeneration() {
-        let generatedNotification = NotificationCenter.generateNotification(typedNotification: self.passingTypedPayloadNotification)
+        let generatedNotification = NotificationCenter.generateNotification(typedNotification: self.passingTypedPayloadNotification, object: TypedNotificationTests.testObject)
         XCTAssertTrue(generatedNotification == passingNotification, "passingTypedNotification was expected to generate a matching notification")
+
+        guard let testInt = generatedNotification.object as? Int else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(testInt, TypedNotificationTests.testObject, "passingTypedNotification was expected to generate a matching notification")
     }
 
     func testIncorrectTypedPayloadNotificationGeneration() {


### PR DESCRIPTION
Moving from using the `object` property to store the payload to a private key in the `userInfo` dictionary on a `Notification`.